### PR TITLE
Fix section parsing to separate unlabeled verses

### DIFF
--- a/bnt_parser/services/song_service.py
+++ b/bnt_parser/services/song_service.py
@@ -107,33 +107,30 @@ class SongService:
         """
         self.sections = []
 
-        if self.lyrics[0][0] != '[':
-            # If the first line is not a section header, treat the entire lyrics as a single verse
-            self.sections.append({
-                'type': 'Verse',
-                'song_order': 1,
-                'lines': self.lyrics,
-            })
+        song_order = 1
+        section = self.new_section(song_order)
 
-            return
-
-        section = {'lines': []}
         for line in self.lyrics:
-            if line.startswith('['):
-                if section and len(section['lines']) > 0:
-                    # If we are already in a section and it has lines, save it
+            # Empty line indicates new section
+            if line.strip() == '' and len(section['lines']) > 0:
+                self.sections.append(section)
+                song_order += 1
+                section = self.new_section(song_order)
+
+            # Section types are in brackets
+            elif line.startswith('['):
+                if len(section['lines']) > 0:
+                    # If we were already in a section and it has lines, save it
                     self.sections.append(section)
+                    song_order += 1
+                    section = self.new_section(song_order)
 
                 index_end = line.find(' ')
                 if index_end == -1:
                     # If no space found, treat the whole line as a section type
                     index_end = line.find(']')
                 section_type = line[1:index_end]
-                section = {
-                    'type': section_type,
-                    'song_order': len(self.sections) + 1,  # Incremental order
-                    'lines': [],
-                }
+                section['type'] = section_type
 
             else:
                 if len(line) > 0 and section is not None: # Do not add empty lines
@@ -141,6 +138,13 @@ class SongService:
 
         if section and len(section['lines']) > 0:
             self.sections.append(section)
+
+    def new_section(self, order):
+        return {
+            'type': '',
+            'song_order': order,
+            'lines': [],
+        }
 
     def parse_words(self, line: str) -> list[str]:
         """

--- a/bnt_parser/tables/section_table.py
+++ b/bnt_parser/tables/section_table.py
@@ -14,6 +14,7 @@ class SectionTable:
         :param section_data: Object containing section data.
         :return: The saved Section object.
         """
+        # Default to Verse if type is not recognized
         if section_data['type'] in Section.SectionTypeEnum.labels:
             try:
                 section_type = Section.SectionTypeEnum[section_data['type'].upper()]

--- a/bnt_parser/tests.py
+++ b/bnt_parser/tests.py
@@ -271,13 +271,16 @@ class SongServiceTestCase(TestCase):
             '[Chorus]',
             'First line of chorus',
             'Second line of chorus',
-            '', # Empty line should be ignored
-            'Third line of chorus',
+            '', # Empty line should start a new section labelled verse
+            'First standalone line',
+            'Second standalone line',
             '',
             '[Solo]', # Ignore empty section
             ''
             '[Verse 2]',
             'Line in second verse',
+            '[Verse 3]', # Section type should start a new section even without empty line
+            'Line in third verse',
             '',
             '[Outro]', # Ignore empty section
         ]
@@ -296,14 +299,28 @@ class SongServiceTestCase(TestCase):
                 'lines': [
                     'First line of chorus',
                     'Second line of chorus',
-                    'Third line of chorus',
+                ],
+            },
+            {
+                'type': '',
+                'song_order': 3,
+                'lines': [
+                    'First standalone line',
+                    'Second standalone line',
                 ],
             },
             {
                 'type': 'Verse',
-                'song_order': 3,
+                'song_order': 4,
                 'lines': [
                     'Line in second verse',
+                ],
+            },
+            {
+                'type': 'Verse',
+                'song_order': 5,
+                'lines': [
+                    'Line in third verse',
                 ],
             },
         ]


### PR DESCRIPTION
1. Blank lines should be seen as separators, creating a new section
2. Unlabeled sections should be labeled verses by default